### PR TITLE
Add thousand divider and fix rouding numbers in BE

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,10 @@
         "webpack-merge": "^5.8.0"
     },
     "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "bignumber.js": "^9.1.1",
+        "bn.js": "^5.2.1",
+        "ethers": "^6.0.2",
         "path": "^0.12.7"
     }
 }

--- a/src/app/components/CamAmount.tsx
+++ b/src/app/components/CamAmount.tsx
@@ -1,23 +1,21 @@
 import * as React from 'react'
-import { Typography, Box } from '@mui/material'
+import { Typography, Tooltip, Box } from '@mui/material'
 import { ReactComponent as GasStationOutline } from './assets/gas-station-outline.svg'
 import { ReactComponent as ACamIcon } from './assets/a-cam.svg'
 import { ReactComponent as NCamIcon } from './assets/n-cam.svg'
 import { ReactComponent as CamIcon } from './assets/cam.svg'
-import { getDisplayAmount, getACamAmount, abbreviateNumber } from '../../utils/currency-utils'
+import {
+    getDisplayAmount,
+    getACamAmount,
+    customToLocaleString,
+    roundedToLocaleString,
+} from '../../utils/currency-utils'
 
 export function AmountIcon({ currency }) {
     return (
-        <div
-            style={{
-                width: '26px',
-                height: '26px',
-                marginLeft: '6px',
-                marginRight: '6px',
-            }}
-        >
-            {currency === 'nCam' ? <NCamIcon /> : currency === 'aCAM' ? <ACamIcon /> : <CamIcon />}
-        </div>
+        <Box sx={{ width: '26px', height: '26px', marginLeft: '6px', marginRight: '6px' }}>
+            {currency === 'nCAM' ? <NCamIcon /> : currency === 'aCAM' ? <ACamIcon /> : <CamIcon />}
+        </Box>
     )
 }
 
@@ -25,52 +23,95 @@ export function CamAmount({
     amount,
     currency = 'aCam',
     style,
-    abbreviate = false,
+    camAmountStyle,
+    abbreviate = true,
 }: {
     amount: number
     currency?: string
     style?: React.CSSProperties
+    camAmountStyle?: React.CSSProperties
     abbreviate?: boolean
 }) {
+    const tooltipAmount = customToLocaleString(getDisplayAmount(amount).value, 20, false)
+    const tooltipCurrency = getDisplayAmount(getACamAmount(amount, currency)).currency
+    const tooltipText = `${tooltipAmount} ${tooltipCurrency}`
+
     return (
-        <Box
-            sx={{
-                display: 'flex',
-                width: 'min-content',
-                flexDirection: 'row',
-                alignItems: 'center',
-                ...style,
-            }}
-        >
-            {abbreviate ? (
-                <Typography variant="subtitle2">
-                    {abbreviateNumber(getDisplayAmount(getACamAmount(amount, currency)).value)}
-                </Typography>
-            ) : (
-                <Typography variant="subtitle1">
-                    {getDisplayAmount(getACamAmount(amount, currency)).value.toLocaleString(
-                        'en-US',
+        <AmountTooltip value={tooltipText} show={abbreviate} style={style}>
+            <Box
+                sx={{
+                    display: 'flex',
+                    width: 'min-content',
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    ...camAmountStyle,
+                }}
+            >
+                <Typography variant="subtitle2" sx={{ whiteSpace: 'nowrap' }}>
+                    {roundedToLocaleString(
+                        getDisplayAmount(amount).value,
+                        abbreviate ? 4 : 20,
+                        abbreviate,
                     )}
                 </Typography>
-            )}
-            <AmountIcon currency={getDisplayAmount(getACamAmount(amount, currency)).currency} />
-            <Typography
-                variant="caption"
-                sx={{ fontSize: '11px', minWidth: '32px', textAlign: 'left' }}
-            >
-                {getDisplayAmount(getACamAmount(amount, currency)).currency}
-            </Typography>
-        </Box>
+                <AmountIcon currency={getDisplayAmount(getACamAmount(amount, currency)).currency} />
+                <Typography
+                    variant="caption"
+                    sx={{ fontSize: '11px', minWidth: '32px', textAlign: 'left' }}
+                >
+                    {getDisplayAmount(getACamAmount(amount, currency)).currency}
+                </Typography>
+            </Box>
+        </AmountTooltip>
     )
 }
 
-export function GasAmount({ amount }: { amount: number }) {
+export function GasAmount({
+    amount,
+    abbreviate = false,
+}: {
+    amount: number
+    abbreviate?: boolean
+}) {
+    return (
+        <AmountTooltip value={customToLocaleString(amount, 20, false)} show={abbreviate}>
+            <Box
+                sx={{
+                    display: 'flex',
+                    width: 'min-content',
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                }}
+            >
+                <Typography variant="subtitle2" sx={{ whiteSpace: 'nowrap' }}>
+                    {roundedToLocaleString(amount, abbreviate ? 4 : 20, abbreviate)}
+                </Typography>
+                <GasStationOutline style={{ width: '24px', height: '24px', marginLeft: '3px' }} />
+            </Box>
+        </AmountTooltip>
+    )
+}
+
+function AmountTooltip({
+    value,
+    show,
+    style,
+    children,
+}: {
+    value: string
+    show: boolean
+    style?: React.CSSProperties
+    children: React.ReactNode
+}) {
     return (
         <>
-            <Typography variant="body1">
-                {new Intl.NumberFormat('nb-NO', { maximumSignificantDigits: 3 }).format(amount)}
-            </Typography>
-            <GasStationOutline style={{ width: '24px', height: '24px', marginLeft: '6px' }} />
+            {show ? (
+                <Tooltip title={value} placement="top" sx={{ width: 'min-content', ...style }}>
+                    <Box>{children}</Box>
+                </Tooltip>
+            ) : (
+                <Box>{children}</Box>
+            )}
         </>
     )
 }

--- a/src/app/components/DetailsField.tsx
+++ b/src/app/components/DetailsField.tsx
@@ -2,11 +2,12 @@ import React from 'react'
 import { Typography, Box, Grid, Tooltip, Button, Chip } from '@mui/material'
 import { mdiOpenInNew, mdiInformationOutline } from '@mdi/js'
 import { Link } from 'react-router-dom'
-import { CamAmount } from 'app/components/CamAmount'
-import CopyToClipboardButton from 'app/components/CopyToClipboardButton'
-import useWidth from 'app/hooks/useWidth'
+import { CamAmount } from './CamAmount'
+import CopyToClipboardButton from './CopyToClipboardButton'
+import useWidth from '../hooks/useWidth'
 import Icon from '@mdi/react'
-import moment from 'utils/helpers/moment'
+import moment from '../../utils/helpers/moment'
+import { roundedToLocaleString } from '../../utils/currency-utils'
 
 export default function DetailsField({
     field,
@@ -17,6 +18,7 @@ export default function DetailsField({
     detailsLink,
     allowCopy,
     style,
+    abbreviate,
 }: {
     field: string
     value: string | number | object | Element | undefined
@@ -26,6 +28,7 @@ export default function DetailsField({
     detailsLink?: string
     allowCopy?: boolean
     style?: React.CSSProperties
+    abbreviate?: boolean
 }) {
     const getTooltip = (field: string): string | undefined => {
         if (Object.keys(tooltips).includes(field?.toLowerCase())) {
@@ -79,7 +82,7 @@ export default function DetailsField({
                 </Typography>
             </Grid>
             <Grid item xs={12} md zeroMinWidth order={{ xs: 3, md: 2 }}>
-                <Field type={type} value={value} />
+                <Field type={type} value={value} abbreviate={abbreviate} />
             </Grid>
             <>
                 {(detailsLink || allowCopy) &&
@@ -143,13 +146,27 @@ export const Field = ({
     type,
     value,
     fontWeight = 'fontWeightRegular',
+    abbreviate,
 }: {
     type: string
     value: string | number | object | undefined
     fontWeight?: string
+    abbreviate?: boolean
 }) => {
     const { isMobile } = useWidth()
-    if (type === 'string' || type === 'number' || type === 'monospace') {
+    if (type === 'number') {
+        return (
+            <Typography
+                variant="body2"
+                component="span"
+                noWrap={true}
+                fontWeight={fontWeight}
+                sx={{ width: '100%', display: 'block' }}
+            >
+                {roundedToLocaleString(value as number)}
+            </Typography>
+        )
+    } else if (type === 'string' || type === 'monospace') {
         return (
             <Typography
                 variant="body2"
@@ -198,11 +215,11 @@ export const Field = ({
             </Typography>
         )
     } else if (type === 'gwei') {
-        return <CamAmount amount={Number(value)} />
+        return <CamAmount amount={Number(value)} abbreviate={abbreviate} />
     } else if (type === 'wei') {
-        return <CamAmount amount={Number(value)} />
+        return <CamAmount amount={Number(value)} abbreviate={abbreviate} />
     } else if (type === 'ncam') {
-        return <CamAmount currency="ncam" amount={Number(value)} />
+        return <CamAmount currency="ncam" amount={Number(value)} abbreviate={abbreviate} />
     } else return <></>
 }
 

--- a/src/app/components/OverviewCards/index.tsx
+++ b/src/app/components/OverviewCards/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import { Grid } from '@mui/material'
 import { Status } from 'types'
-import { getDisplayValueForGewi } from 'utils/currency-utils'
+import { getDisplayValueForGewi, customToLocaleString } from 'utils/currency-utils'
 import OverviewCard from './OverviewCard'
 import { useNavigate } from 'react-router-dom'
 import { VALIDATORS } from 'utils/route-paths'
@@ -33,7 +33,7 @@ const OverviewCards: FC<OverviewCardsProps> = ({
             <Grid item xs={12} lg={4}>
                 <OverviewCard
                     title="Number Of Validators"
-                    value={numberOfValidators.toString()}
+                    value={customToLocaleString(numberOfValidators, 0)}
                     loading={validatorsLoading}
                     subValue={`(${numberOfActiveValidators} / ${percentageOfActiveValidators}% active)`}
                     onClick={() => navigate(VALIDATORS)}
@@ -42,7 +42,7 @@ const OverviewCards: FC<OverviewCardsProps> = ({
             <Grid item xs={12} lg={4}>
                 <OverviewCard
                     title="Number of Transactions"
-                    value={numberOfTransactions.toLocaleString('en-US')}
+                    value={customToLocaleString(numberOfTransactions, 2)}
                     loading={transactionsLoading}
                 />
             </Grid>

--- a/src/app/components/PageContainer.tsx
+++ b/src/app/components/PageContainer.tsx
@@ -12,7 +12,7 @@ export default function PageContainer({
     children: React.ReactNode
 }) {
     return (
-        <Container fixed maxWidth="xl" sx={{ minHeight: '500px', px: '0px' }}>
+        <Container maxWidth="xl" sx={{ minHeight: '500px', px: '0px' }}>
             <Helmet>
                 <title>{pageTitle}</title>
                 <meta name="description" content={metaContent} />

--- a/src/app/components/XChainPageComponents/XPTransactionItem.tsx
+++ b/src/app/components/XChainPageComponents/XPTransactionItem.tsx
@@ -118,14 +118,14 @@ const XPTransactionSecondSection = ({
                                 <CamAmount
                                     amount={tx.value}
                                     currency="nCam"
-                                    style={{
-                                        marginLeft: !isMobile ? 'auto' : '',
+                                    camAmountStyle={{
                                         color:
                                             from &&
                                             from[0] &&
                                             tx.address === from[0].address &&
                                             '#616161',
                                     }}
+                                    style={{ marginLeft: !isMobile ? 'auto' : '' }}
                                 />
                             </Grid>
                             {index === 4 && dataLeft > 0 && (

--- a/src/app/pages/CChainPages/Blocks/Block.tsx
+++ b/src/app/pages/CChainPages/Blocks/Block.tsx
@@ -66,19 +66,19 @@ const GridItem = ({ block }: { block: BlockTableData }) => {
                 <Typography variant="subtitle2" color="latestList.timestamp">
                     hash
                 </Typography>
-                <Field type="number" value={block.hash} />
+                <Field type="hexdata" value={block.hash} />
             </Grid>
             <Grid item xs={12} md zeroMinWidth order={{ xs: 3, md: 2 }}>
                 <Typography variant="subtitle2" color="latestList.timestamp">
                     Gas Used
                 </Typography>
-                <Field type="string" value={block.gasUsed?.toString()} />
+                <Field type="string" value={block.gasUsed} />
             </Grid>
             <Grid item xs={12} md zeroMinWidth order={{ xs: 3, md: 2 }}>
                 <Typography variant="subtitle2" color="latestList.timestamp">
                     Gas Limit
                 </Typography>
-                <Field type="string" value={block.gasLimit?.toString()} />
+                <Field type="string" value={block.gasLimit} />
             </Grid>
         </>
     )
@@ -107,10 +107,10 @@ const CustomRow = ({ block }: { block: BlockTableData }) => {
                 <Field type="string" value={block.hash} />
             </TableCell>
             <TableCell align="left">
-                <Field type="string" value={block.gasUsed?.toString()} />
+                <Field type="number" value={block.gasUsed} />
             </TableCell>
             <TableCell align="left">
-                <Field type="string" value={block.gasLimit?.toString()} />
+                <Field type="number" value={block.gasLimit} />
             </TableCell>
         </>
     )

--- a/src/app/pages/CChainPages/Blocks/BlockDetailView.tsx
+++ b/src/app/pages/CChainPages/Blocks/BlockDetailView.tsx
@@ -95,7 +95,7 @@ const BlockDetailView: FC<BlockDetailViewProps> = ({ blockDetails, loading }) =>
                                 <DetailsField
                                     field="Gas Limit"
                                     value={blockDetails['gasLimit']}
-                                    type="hexdata"
+                                    type="number"
                                     style={{ padding: '1rem' }}
                                 />
                                 <Divider variant="fullWidth" />
@@ -152,71 +152,7 @@ const BlockDetailView: FC<BlockDetailViewProps> = ({ blockDetails, loading }) =>
                                     type="hexdata"
                                     style={{ padding: '1rem' }}
                                 />
-                                {/* <Divider variant="fullWidth" /> */}
                             </Grid>
-
-                            {/* <Grid item xs={12}>
-                <DetailsField
-                  field="Transactions Root"
-                  value={blockDetails['transactionsRoot']}
-                  type="hexdata"
-                  style={{ padding: '1rem' }}
-                />
-                <Divider variant="fullWidth" />
-              </Grid>
-              <Grid item xs={12}>
-                <DetailsField
-                  field="Receipts Root"
-                  value={blockDetails['receiptsRoot']}
-                  type="hexdata"
-                  style={{ padding: '1rem' }}
-                />
-                <Divider variant="fullWidth" />
-              </Grid>
-              <Grid item xs={12}>
-                <DetailsField
-                  field="Block Gas Cost"
-                  value={blockDetails['blockGasCost']}
-                  type="hexdata"
-                  style={{ padding: '1rem' }}
-                />
-                <Divider variant="fullWidth" />
-              </Grid>
-              <Grid item xs={12}>
-                <DetailsField
-                  field="Mix Hash"
-                  value={blockDetails['mixHash']}
-                  type="hexdata"
-                  style={{ padding: '1rem' }}
-                />
-                <Divider variant="fullWidth" />
-              </Grid>
-              <Grid item xs={12}>
-                <DetailsField
-                  field="Ext Data Hash"
-                  value={blockDetails['extDataHash']}
-                  type="hexdata"
-                  style={{ padding: '1rem' }}
-                />
-                <Divider variant="fullWidth" />
-              </Grid>
-              <Grid item xs={12}>
-                <DetailsField
-                  field="Ext Data Gas Used"
-                  value={blockDetails['extDataGasUsed']}
-                  type="hexdata"
-                  style={{ padding: '1rem' }}
-                />
-                <Divider variant="fullWidth" />
-              </Grid>
-              <Grid item xs={12}>
-                <DetailsField
-                  field="Logs Bloom"
-                  value={blockDetails['logsBloom']}
-                  type="hexdata"
-                  style={{ padding: '1rem' }}
-                />
-              </Grid> */}
                         </Grid>
                     </OutlinedContainer>
                 </>

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/BlockList.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/BlockList.tsx
@@ -17,11 +17,13 @@ const BlockList: FC<BlockListProps> = ({ title, items, to }) => {
             variant="outlined"
             square
             sx={{
+                display: 'flex',
                 backgroundColor: 'card.background',
                 borderWidth: '1px',
                 borderColor: 'primary.light',
                 borderStyle: 'solid',
                 p: '1rem 1.5rem 1rem 1.5rem',
+                flexDirection: 'column',
             }}
         >
             {title && (

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/BlockList.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/BlockList.tsx
@@ -24,6 +24,7 @@ const BlockList: FC<BlockListProps> = ({ title, items, to }) => {
                 borderStyle: 'solid',
                 p: '1rem 1.5rem 1rem 1.5rem',
                 flexDirection: 'column',
+                height: '100%',
             }}
         >
             {title && (

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/Items/BlockItem.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/Items/BlockItem.tsx
@@ -69,7 +69,7 @@ const BlockItem: FC<BlockItemProps> = ({ block, to }) => {
                 alignItems="center"
                 justifyContent={!isDesktop ? 'flex-start' : 'flex-end'}
             >
-                <GasAmount amount={block.gasUsed as number} />
+                <GasAmount amount={block.gasUsed as number} abbreviate />
             </Grid>
         </Grid>
     )

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/ShowAllButton.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/ShowAllButton.tsx
@@ -7,11 +7,11 @@ const ShowAllButton = ({ toLink }: { toLink: string }) => {
     return (
         <Box
             sx={{
-                marginTop: '1rem',
                 width: '100%',
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
+                marginTop: 'auto',
             }}
         >
             <Link style={{ textDecoration: 'none' }} to={toLink} rel="noopener noreferrer">

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/TransactionsList.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/TransactionsList.tsx
@@ -63,10 +63,16 @@ const TransactionsList: FC<TransactionsListProps> = ({ title, items, to, link })
                 variant="caption"
                 component="span"
                 fontWeight="fontWeightBold"
-                sx={{ color: 'error.main', alignSelf: 'flex-end', my: '.5rem' }}
+                sx={{
+                    color: 'error.main',
+                    alignSelf: 'flex-end',
+                    my: '.5rem',
+                    fontSize: '11px',
+                    textAlign: 'right',
+                }}
             >
-                Transaction values are approximate, hover on number or click on transaction to view
-                full details.
+                Some transaction values may be approximate <br /> Hover over number or click on
+                transaction to view full details.
             </Typography>
             {link && <ShowAllButton toLink="transactions" />}
         </Paper>

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/TransactionsList.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/TransactionsList.tsx
@@ -25,6 +25,7 @@ const TransactionsList: FC<TransactionsListProps> = ({ title, items, to, link })
                 borderStyle: 'solid',
                 p: '1rem 1.5rem 1rem 1.5rem',
                 flexDirection: 'column',
+                height: '100%',
             }}
         >
             {title && (
@@ -64,7 +65,8 @@ const TransactionsList: FC<TransactionsListProps> = ({ title, items, to, link })
                 fontWeight="fontWeightBold"
                 sx={{ color: 'error.main', alignSelf: 'flex-end', my: '.5rem' }}
             >
-                Hover on tx value to view full exact amount.
+                Transaction values are approximate, hover on number or click on transaction to view
+                full details.
             </Typography>
             {link && <ShowAllButton toLink="transactions" />}
         </Paper>

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/TransactionsList.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/TransactionsList.tsx
@@ -18,11 +18,13 @@ const TransactionsList: FC<TransactionsListProps> = ({ title, items, to, link })
             variant="outlined"
             square
             sx={{
+                display: 'flex',
                 backgroundColor: 'card.background',
                 borderWidth: '1px',
                 borderColor: 'primary.light',
                 borderStyle: 'solid',
                 p: '1rem 1.5rem 1rem 1.5rem',
+                flexDirection: 'column',
             }}
         >
             {title && (
@@ -56,6 +58,14 @@ const TransactionsList: FC<TransactionsListProps> = ({ title, items, to, link })
                     <CircularProgress color="secondary" />
                 </Box>
             )}
+            <Typography
+                variant="caption"
+                component="span"
+                fontWeight="fontWeightBold"
+                sx={{ color: 'error.main', alignSelf: 'flex-end', my: '.5rem' }}
+            >
+                Hover on tx value to view full exact amount.
+            </Typography>
             {link && <ShowAllButton toLink="transactions" />}
         </Paper>
     )

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/index.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/index.tsx
@@ -17,10 +17,10 @@ const LatestBlocksAndTransactionsList: FC<LatestBlocksAndTransactionsListProps> 
 }) => {
     return (
         <Grid container rowSpacing={{ xs: 4, lg: '0!important' }} columnSpacing={{ xs: 0, lg: 4 }}>
-            <Grid item xs={12} lg={6} sx={{ gridTemplateColumns: '1fr', display: 'grid' }}>
+            <Grid item xs={12} lg={6}>
                 <BlockList title="Latest Blocks" items={blocks} to={`${CBLOCKS}`} />
             </Grid>
-            <Grid item xs={12} lg={6} sx={{ gridTemplateColumns: '1fr', display: 'grid' }}>
+            <Grid item xs={12} lg={6}>
                 <TransactionsList
                     title="Latest Transactions"
                     items={transactions}

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/index.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/index.tsx
@@ -17,10 +17,10 @@ const LatestBlocksAndTransactionsList: FC<LatestBlocksAndTransactionsListProps> 
 }) => {
     return (
         <Grid container rowSpacing={{ xs: 4, lg: '0!important' }} columnSpacing={{ xs: 0, lg: 4 }}>
-            <Grid item xs={12} lg={6}>
+            <Grid item xs={12} lg={6} sx={{ gridTemplateColumns: '1fr', display: 'grid' }}>
                 <BlockList title="Latest Blocks" items={blocks} to={`${CBLOCKS}`} />
             </Grid>
-            <Grid item xs={12} lg={6}>
+            <Grid item xs={12} lg={6} sx={{ gridTemplateColumns: '1fr', display: 'grid' }}>
                 <TransactionsList
                     title="Latest Transactions"
                     items={transactions}

--- a/src/app/pages/CChainPages/Transactions/Transaction.tsx
+++ b/src/app/pages/CChainPages/Transactions/Transaction.tsx
@@ -168,7 +168,7 @@ const CustomRow: FC<TransactionProps> = ({ transaction }) => {
                         'MMM D, YYYY, h:mm:ss A ([GMT] ZZ)',
                     )}
                 >
-                    <Typography variant="body2" component="span">
+                    <Typography variant="caption" component="span">
                         {isDesktop
                             ? moment(transaction.timestamp).format('h:mm:ss A\xa0- DD.MM.YYYY')
                             : moment(transaction.timestamp).format('h:mm:ss A\xa0-\xa0DD.MM.YYYY')}

--- a/src/app/pages/CChainPages/Transactions/TransactionDetailView.tsx
+++ b/src/app/pages/CChainPages/Transactions/TransactionDetailView.tsx
@@ -134,6 +134,7 @@ const TransactionDetailView: FC<TxDetailsViewProps> = ({ detailTr, detailCr, loa
                                 value={detailCr['value'] ? detailCr['value'] : '0'}
                                 type="wei"
                                 style={{ padding: '1rem' }}
+                                abbreviate={false}
                             />
                             <Divider variant="fullWidth" />
                         </Grid>
@@ -143,6 +144,7 @@ const TransactionDetailView: FC<TxDetailsViewProps> = ({ detailTr, detailCr, loa
                                 value={detailCr['transactionCost']}
                                 type="wei"
                                 style={{ padding: '1rem' }}
+                                abbreviate={false}
                             />
                         </Grid>
                     </Grid>

--- a/src/app/pages/XChainPages/Transactions/Transaction.tsx
+++ b/src/app/pages/XChainPages/Transactions/Transaction.tsx
@@ -210,7 +210,7 @@ const CustomRow = ({ transaction }) => {
                         'MMM D, YYYY, h:mm:ss A ([GMT] ZZ)',
                     )}
                 >
-                    <Typography variant="body2" component="span" noWrap={true}>
+                    <Typography variant="caption" component="span" noWrap={true}>
                         {moment(transaction.timestamp).format('h:mm:ss A\xa0-\xa0DD.MM.YYYY')}
                     </Typography>
                 </NoMaxWidthTooltip>

--- a/src/store/cchainSlice/index.ts
+++ b/src/store/cchainSlice/index.ts
@@ -106,7 +106,7 @@ const cchainSlice = createSlice({
                     // parentBlockNumber: parseInt(action.payload.header.number), to review
                     baseGaseFee: parseInt(action.payload.header.baseFeePerGas),
                     fees: 0,
-                    gasUsed: parseInt(action.payload.header.gasUsed).toLocaleString('en-US'),
+                    gasUsed: parseInt(action.payload.header.gasUsed),
                     time: new Date(parseInt(action.payload.header.timestamp) * 1000).toString(),
                     transactionsCount: action.payload.transactions
                         ? action.payload.transactions.length
@@ -168,7 +168,7 @@ const cchainSlice = createSlice({
                     gasPrice: parseInt(payload.gasPrice),
                     maxFeePerGas: parseInt(payload.maxFeePerGas),
                     maxPriorityFeePerGas: parseInt(payload.maxPriorityFeePerGas),
-                    gasUsed: parseInt(payload.receipt.gasUsed).toLocaleString('en-US'),
+                    gasUsed: parseInt(payload.receipt.gasUsed),
                     effectiveGasPrice: parseInt(payload.receipt.effectiveGasPrice),
                     transactionCost:
                         parseInt(payload.receipt.gasUsed) *

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -17,8 +17,8 @@ export interface XPTransaction {
     from: Fund[]
     to: Fund[]
     fee: number
-    inputTotals: Record<string, string>
-    outputTotals: Record<string, string>
+    inputTotals: Record<string, number>
+    outputTotals: Record<string, number>
     memo?: string
 }
 

--- a/src/utils/currency-utils.ts
+++ b/src/utils/currency-utils.ts
@@ -1,4 +1,5 @@
 import { Amount } from './types/currency-type'
+import BigNumber from 'bignumber.js'
 
 const conversionACamPerCam = 1000000000000000000
 
@@ -9,19 +10,27 @@ export const ACAM_CAM_CONVERSION_THRESHHOLD = 1000000000000000
 export const ACAM_NCAM_CONVERSION_THRESHHOLD = 1000000
 
 export function aCamToCam(aCam: number) {
-    return aCam / conversionACamPerCam
+    let value = new BigNumber(aCam)
+    let converter = new BigNumber(conversionACamPerCam)
+    return value.dividedBy(converter).toNumber()
 }
 
 export function aCamToNCam(aCam: number) {
-    return aCam / conversionACamPerNCam
+    let value = new BigNumber(aCam)
+    let converter = new BigNumber(conversionACamPerNCam)
+    return value.dividedBy(converter).toNumber()
 }
 
 export function nCamToACam(nCam: number) {
-    return nCam * conversionACamPerNCam
+    let value = new BigNumber(nCam)
+    let converter = new BigNumber(conversionACamPerNCam)
+    return value.dividedBy(converter).toNumber()
 }
 
 export function getDisplayValueForGewi(nCamVal: number): string {
-    return getDisplayValue(nCamVal * conversionACamPerNCam)
+    let value = new BigNumber(nCamVal)
+    let converter = new BigNumber(conversionACamPerNCam)
+    return getDisplayValue(value.multipliedBy(converter).toNumber())
 }
 
 export function getDisplayValue(aCam: number): string {
@@ -31,9 +40,9 @@ export function getDisplayValue(aCam: number): string {
 
 export function getACamAmount(value: number, currency: string): number {
     if (currency.toLowerCase() === 'cam') {
-        return value * conversionACamPerCam
+        return new BigNumber(value).multipliedBy(new BigNumber(conversionACamPerCam)).toNumber()
     } else if (currency.toLowerCase() === 'ncam') {
-        return value * conversionACamPerNCam
+        return new BigNumber(value).multipliedBy(new BigNumber(conversionACamPerNCam)).toNumber()
     } else {
         return value
     }
@@ -62,7 +71,7 @@ export function getDisplayAmount(aCam: number): Amount {
 }
 
 export function formatAmount(value: number, currency: string): string {
-    return `${value.toLocaleString()} ${currency}`
+    return `${customToLocaleString(value)} ${currency}`
 }
 
 // ToDo: Update this function
@@ -76,6 +85,52 @@ export function abbreviateNumber(value: number): string {
     } else {
         return value.toString()
     }
+}
+
+export function customToLocaleString(value, toFixed = 4, abbreviate = false) {
+    if (!abbreviate) {
+        let unrounded = value.toFixed(20)
+        let split = unrounded.split('.')
+        let wholeStr = parseInt(split[0])
+            .toString()
+            .replace(/\B(?=(\d{3})+(?!\d))/g, '\u2005')
+
+        if (split.length === 1) {
+            return wholeStr
+        } else {
+            let remainderStr = split[1]
+            let lastChar = remainderStr.charAt(remainderStr.length - 1)
+            while (lastChar === '0') {
+                remainderStr = remainderStr.substring(0, remainderStr.length - 1)
+                lastChar = remainderStr.charAt(remainderStr.length - 1)
+            }
+            let trimmed = remainderStr.substring(0, toFixed)
+            if (!trimmed) return wholeStr
+            return `${wholeStr}.${trimmed}`
+        }
+    } else {
+        if (value <= 0.0000999999 && value !== 0) return '< 0.0001'
+
+        let prefixes = ['', 'M', 'B', 'T']
+        let prefix = 0
+        while (value >= 1000000) {
+            value /= 1000000
+            prefix++
+        }
+        return customToLocaleString(value, toFixed, false) + prefixes[prefix]
+    }
+}
+
+export function roundedToLocaleString(value, toFixed = 4, abbreviate = false) {
+    let result = customToLocaleString(value, toFixed, abbreviate)
+    if (result.includes('.')) {
+        let [wholeStr, trimmed] = result.split('.')
+
+        if (trimmed.split('').every(char => char === '0')) {
+            return '~' + wholeStr
+        }
+    }
+    return result
 }
 
 export const currencyFields = [

--- a/src/utils/magellan/index.ts
+++ b/src/utils/magellan/index.ts
@@ -29,7 +29,7 @@ export function createTransaction(magellanTransaction: MagellanXPTransaction): X
         type: magellanTransaction.type,
         from: getInputFunds(magellanTransaction),
         to: getOutputFunds(magellanTransaction),
-        fee: magellanTransaction.txFee,
+        fee: parseInt(magellanTransaction.txFee),
         inputTotals: magellanTransaction.inputTotals,
         outputTotals: magellanTransaction.outputTotals,
         status: 'accepted', //TODO: set dynamically when magellan delivers this information
@@ -59,6 +59,6 @@ export function getInputFunds(magellanTransaction: MagellanXPTransaction): Fund[
 function createFundFromOutput(magellanOutput: MagellanXPOutput): Fund {
     return {
         address: magellanOutput && magellanOutput.addresses ? magellanOutput.addresses[0] : null,
-        value: magellanOutput.amount,
+        value: parseInt(magellanOutput.amount),
     } as Fund
 }


### PR DESCRIPTION
-  Added a 6-per-em space thousand separators in the block explorer (BE)
-  The separator abbreviates values with M, B, and T on every page except for the detail pages
-  Add a ~ for approximated numbers

![Screenshot 2023-02-13 at 16 51 22](https://user-images.githubusercontent.com/58547974/218506590-878f344d-8fa3-43e1-afbc-e5e49a8cfb34.JPG)
![Screenshot 2023-02-13 at 16 51 40](https://user-images.githubusercontent.com/58547974/218506572-c2ea5036-84d0-49c8-a273-214fb08bced9.JPG)
![Screenshot 2023-02-13 at 16 51 29](https://user-images.githubusercontent.com/58547974/218506585-15777646-2ece-41b8-b92f-987c3e22b64c.JPG)

