### PR TITLE
Revise block explorer routing to meet EIP-3091 standards

### DIFF
--- a/src/app/components/NavBar/SearchInput.tsx
+++ b/src/app/components/NavBar/SearchInput.tsx
@@ -16,6 +16,7 @@ import { useNavigate } from 'react-router-dom'
 import { useAppSelector } from 'store/configureStore'
 import { selectMagellanAddress } from 'store/app-config'
 import { searchApi } from 'utils/magellan-api-utils'
+import { BASE_PATH } from 'utils/route-paths'
 
 function OutlinedSearchInput() {
     const theme = useTheme()
@@ -84,7 +85,7 @@ function OutlinedSearchInput() {
 
     useEffect(() => {
         handleSearch()
-  }, [search]); // eslint-disable-line
+    }, [search]) // eslint-disable-line
 
     return (
         <Box
@@ -259,7 +260,7 @@ const SearchResultMenuList = ({ menuItems }) => {
                 <MenuItem
                     key={item.label + Math.random().toString(36).substring(2, 15)}
                     onClick={() => {
-                        navigate(`/explorer${item.link}`)
+                        navigate(`${BASE_PATH}/${item.link}`)
                     }}
                     sx={{ gap: '10px' }}
                 >

--- a/src/app/components/XChainPageComponents/XPTransactionItem.tsx
+++ b/src/app/components/XChainPageComponents/XPTransactionItem.tsx
@@ -8,7 +8,7 @@ import RelativeTime from 'app/components/RelativeTime'
 import AddressLink from '../AddressLink'
 import BlockTxIcon from './BlockTxIcon'
 import useWidth from 'app/hooks/useWidth'
-import { BASE_PATH } from '../../../utils/route-paths'
+import { BASE_PATH, ADDRESS, TRANSACTION } from '../../../utils/route-paths'
 
 export default function XPTransactionItem({ chainType, data }) {
     return (
@@ -18,7 +18,7 @@ export default function XPTransactionItem({ chainType, data }) {
                     id={data.id}
                     timestamp={data.timestamp}
                     type={data.type}
-                    to={`${BASE_PATH}/${chainType}/transactions/${data.id}`}
+                    to={`${BASE_PATH}/${chainType}${TRANSACTION}/${data.id}`}
                 />
             </Grid>
             <Grid container item xs={12} md={8} columnSpacing={2}>
@@ -105,7 +105,7 @@ const XPTransactionSecondSection = ({
                         <Grid container style={{ padding: '0rem 0rem .5rem 0rem' }} key={index}>
                             <Grid item xs={12} sm={6} xl={7}>
                                 <AddressLink
-                                    to={`${BASE_PATH}/${chainType}/address/${getAddressLink(
+                                    to={`${BASE_PATH}/${chainType}${ADDRESS}/${getAddressLink(
                                         chainType,
                                         tx.address,
                                     )}`}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -29,30 +29,22 @@ export function App() {
                     />
                     <Route path="c-chain">
                         <Route index element={<CChainPage />} />
-                        <Route path="blocks">
-                            <Route index element={<Blocks />} />
-                            <Route path=":id" element={<BlockDetails />} />
-                        </Route>
-                        <Route path="transactions">
-                            <Route index element={<CTransactions />} />
-                            <Route path=":id" element={<TransactionDetails />} />
-                        </Route>
+                        <Route path="blocks" element={<Blocks />} />
+                        <Route path="txs" element={<CTransactions />} />
+                        <Route path="block/:id" element={<BlockDetails />} />
+                        <Route path="tx/:id" element={<TransactionDetails />} />
                         <Route path="address/:id" element={<Address />} />
                     </Route>
                     <Route path="x-chain">
                         <Route index element={<XChainPage />} />
-                        <Route path="transactions">
-                            <Route index element={<XPTransactions />} />
-                            <Route path=":id" element={<XPTransactionDetails />} />
-                        </Route>
+                        <Route path="txs" element={<XPTransactions />} />
+                        <Route path="tx/:id" element={<XPTransactionDetails />} />
                         <Route path="address/:id" element={<XAddressDetail />} />
                     </Route>
                     <Route path="p-chain">
                         <Route index element={<PChainPage />} />
-                        <Route path="transactions">
-                            <Route index element={<XPTransactions />} />
-                            <Route path=":id" element={<XPTransactionDetails />} />
-                        </Route>
+                        <Route path="txs" element={<XPTransactions />} />
+                        <Route path="tx/:id" element={<XPTransactionDetails />} />
                         <Route path="address/:id" element={<XAddressDetail />} />
                     </Route>
                     <Route path={`${BASE_PATH}/mainnet`} element={<ComingSoonPage />} />

--- a/src/app/pages/CChainPages/Address/Address.tsx
+++ b/src/app/pages/CChainPages/Address/Address.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import { Grid, Paper, TableCell, TableRow, Typography, Chip } from '@mui/material'
 import { Field } from 'app/components/DetailsField'
-import { CADDRESS, CTRANSACTIONS, CBLOCKS } from 'utils/route-paths'
+import { CADDRESS, CTRANSACTION, CBLOCKS } from 'utils/route-paths'
 import { CAddressTransactionTableData } from 'types/transaction'
 import AddressLink from 'app/components/AddressLink'
 import useWidth from 'app/hooks/useWidth'
@@ -84,7 +84,7 @@ const CustomRow: FC<GridItemProps> = ({ transaction }) => {
             </TableCell>
             <TableCell align="left" sx={{ maxWidth: { xs: '10px', md: '80px', lg: '165px' } }}>
                 <AddressLink
-                    to={`${CTRANSACTIONS}/${transaction.hash}`}
+                    to={`${CTRANSACTION}/${transaction.hash}`}
                     value={transaction.hash}
                     typographyVariant="body2"
                     truncate={true}
@@ -155,7 +155,7 @@ const GridItem: FC<GridItemProps> = ({ transaction }) => {
                     Txn Hash
                 </Typography>
                 <AddressLink
-                    to={`${CTRANSACTIONS}/${transaction.hash}`}
+                    to={`${CTRANSACTION}/${transaction.hash}`}
                     value={transaction.hash}
                     typographyVariant="body2"
                     truncate={true}

--- a/src/app/pages/CChainPages/Blocks/Block.tsx
+++ b/src/app/pages/CChainPages/Blocks/Block.tsx
@@ -5,6 +5,7 @@ import { BlockTableData } from 'types/block'
 import useWidth from 'app/hooks/useWidth'
 import AddressLink from 'app/components/AddressLink'
 import FilledCard from 'app/components/FilledCard'
+import { CBLOCKS } from 'utils/route-paths'
 import moment from 'moment'
 
 interface BlockProps {
@@ -44,7 +45,7 @@ const GridItem = ({ block }: { block: BlockTableData }) => {
                     Block
                 </Typography>
                 <AddressLink
-                    to={`${block.number}`}
+                    to={`${CBLOCKS}/${block.number}`}
                     value={block.number}
                     typographyVariant="body1"
                     truncate={false}
@@ -89,7 +90,7 @@ const CustomRow = ({ block }: { block: BlockTableData }) => {
         <>
             <TableCell>
                 <AddressLink
-                    to={`${block.number}`}
+                    to={`${CBLOCKS}/${block.number}`}
                     value={block.number}
                     typographyVariant="body1"
                     truncate={false}

--- a/src/app/pages/CChainPages/Blocks/BlockDetails.tsx
+++ b/src/app/pages/CChainPages/Blocks/BlockDetails.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom'
 import { useAppDispatch, useAppSelector } from 'store/configureStore'
 import { fetchCBlockDetail } from 'store/cchainSlice/utils'
 import { getCBlockDetail, getCBlockDetailStatus } from 'store/cchainSlice'
-import { CCHAIN, CTRANSACTIONS } from 'utils/route-paths'
+import { CCHAIN } from 'utils/route-paths'
 import { Status } from 'types'
 import LoadingWrapper from 'app/components/LoadingWrapper'
 import TransactionsList from 'app/pages/CChainPages/LatestBlocksAndTransactionsList/TransactionsList'
@@ -88,7 +88,6 @@ const TransactionsView: FC<TransactionsViewProps> = ({ loading, blockDetails }) 
                     <TransactionsList
                         title="Block Transactions"
                         items={blockDetails?.transactions}
-                        to={CTRANSACTIONS}
                         link={false}
                     />
                 </Grid>

--- a/src/app/pages/CChainPages/Blocks/index.tsx
+++ b/src/app/pages/CChainPages/Blocks/index.tsx
@@ -20,7 +20,7 @@ const Blocks: FC = () => {
         data,
         status,
         // error,
-    } = useInfiniteQuery('/blocks', ({ pageParam = NaN }) => getBlocksPage(pageParam), {
+    } = useInfiniteQuery('/block', ({ pageParam = NaN }) => getBlocksPage(pageParam), {
         getNextPageParam: (lastPage, allPages) => {
             return lastPage.length ? lastPage[lastPage.length - 1].number - 1 : undefined
         },

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/BlockList.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/BlockList.tsx
@@ -4,6 +4,7 @@ import { BlockTableData } from 'types/block'
 import Divider from '@mui/material/Divider'
 import ShowAllButton from './ShowAllButton'
 import BlockItem from './Items/BlockItem'
+import { CCHAIN, BLOCKS } from 'utils/route-paths'
 
 interface BlockListProps {
     title: string
@@ -58,7 +59,7 @@ const BlockList: FC<BlockListProps> = ({ title, items, to }) => {
                     <CircularProgress color="secondary" />
                 </Box>
             )}
-            <ShowAllButton toLink="blocks" />
+            <ShowAllButton toLink={`${CCHAIN}${BLOCKS}`} />
         </Paper>
     )
 }

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/Items/TransactionItem.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/Items/TransactionItem.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, Grid } from '@mui/material'
 import { mdiTransfer } from '@mdi/js'
 import { CamAmount } from '../../../../components/CamAmount'
 import { CTransaction } from 'types/transaction'
-import { CADDRESS } from 'utils/route-paths'
+import { CADDRESS, CTRANSACTION } from 'utils/route-paths'
 import Icon from '@mdi/react'
 import AddressLink from '../../../../components/AddressLink'
 import RelativeTime from '../../../../components/RelativeTime'
@@ -11,10 +11,9 @@ import useWidth from 'app/hooks/useWidth'
 
 interface TransactionItemProps {
     transaction: CTransaction
-    to: string
 }
 
-const TransactionItem: FC<TransactionItemProps> = ({ transaction, to }) => {
+const TransactionItem: FC<TransactionItemProps> = ({ transaction }) => {
     const { isMobile, isTablet, isDesktop } = useWidth()
     return (
         <Grid
@@ -46,7 +45,7 @@ const TransactionItem: FC<TransactionItemProps> = ({ transaction, to }) => {
             )}
             <Grid item xs={12} md={4} lg={2.5} xl={3} justifyContent="flex-start">
                 <AddressLink
-                    to={`${to}/${transaction.hash}`}
+                    to={`${CTRANSACTION}/${transaction.hash}`}
                     value={transaction.hash}
                     typographyVariant="body1"
                     truncate={true}

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/TransactionsList.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/TransactionsList.tsx
@@ -1,18 +1,18 @@
 import React, { FC } from 'react'
 import { Box, Typography, Paper, CircularProgress } from '@mui/material'
-import { CTransaction } from 'types/transaction'
+import { CTransaction } from '../../../../types/transaction'
 import Divider from '@mui/material/Divider'
 import ShowAllButton from './ShowAllButton'
 import TransactionItem from './Items/TransactionItem'
+import { CCHAIN, TRANSACTIONS } from 'utils/route-paths'
 
 interface TransactionsListProps {
     title: string
     items: CTransaction[]
-    to: string
     link: boolean
 }
 
-const TransactionsList: FC<TransactionsListProps> = ({ title, items, to, link }) => {
+const TransactionsList: FC<TransactionsListProps> = ({ title, items, link }) => {
     return (
         <Paper
             variant="outlined"
@@ -42,7 +42,7 @@ const TransactionsList: FC<TransactionsListProps> = ({ title, items, to, link })
                 <>
                     {items.map((item, index) => (
                         <React.Fragment key={index}>
-                            <TransactionItem transaction={item} to={to} />
+                            <TransactionItem transaction={item} />
                             {index !== items.length - 1 && <Divider variant="fullWidth" />}
                         </React.Fragment>
                     ))}
@@ -74,7 +74,7 @@ const TransactionsList: FC<TransactionsListProps> = ({ title, items, to, link })
                 Some transaction values may be approximate <br /> Hover over number or click on
                 transaction to view full details.
             </Typography>
-            {link && <ShowAllButton toLink="transactions" />}
+            {link && <ShowAllButton toLink={`${CCHAIN}${TRANSACTIONS}`} />}
         </Paper>
     )
 }

--- a/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/index.tsx
+++ b/src/app/pages/CChainPages/LatestBlocksAndTransactionsList/index.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 import { Grid } from '@mui/material'
 import { BlockTableData } from 'types/block'
 import { CTransaction } from 'types/transaction'
-import { CBLOCKS, CTRANSACTIONS } from 'utils/route-paths'
+import { CBLOCKS } from 'utils/route-paths'
 import BlockList from './BlockList'
 import TransactionsList from './TransactionsList'
 
@@ -21,12 +21,7 @@ const LatestBlocksAndTransactionsList: FC<LatestBlocksAndTransactionsListProps> 
                 <BlockList title="Latest Blocks" items={blocks} to={`${CBLOCKS}`} />
             </Grid>
             <Grid item xs={12} lg={6}>
-                <TransactionsList
-                    title="Latest Transactions"
-                    items={transactions}
-                    to={`${CTRANSACTIONS}`}
-                    link
-                />
+                <TransactionsList title="Latest Transactions" items={transactions} link />
             </Grid>
         </Grid>
     )

--- a/src/app/pages/CChainPages/Transactions/Transaction.tsx
+++ b/src/app/pages/CChainPages/Transactions/Transaction.tsx
@@ -8,6 +8,7 @@ import useWidth from 'app/hooks/useWidth'
 import FilledCard from 'app/components/FilledCard'
 import moment from 'utils/helpers/moment'
 import { NoMaxWidthTooltip } from 'app/components/RelativeTime'
+import { CTRANSACTION } from '../../../../utils/route-paths'
 
 interface TransactionProps {
     transaction: TransactionTableData
@@ -80,7 +81,7 @@ const GridItem: FC<TransactionProps> = ({ transaction }) => {
                     Hash
                 </Typography>
                 <AddressLink
-                    to={`${transaction.hash}`}
+                    to={`${CTRANSACTION}/${transaction.hash}`}
                     value={transaction.hash}
                     typographyVariant="body2"
                     truncate={true}
@@ -156,7 +157,7 @@ const CustomRow: FC<TransactionProps> = ({ transaction }) => {
             </TableCell>
             <TableCell align="left" sx={{ maxWidth: { xs: '10px', md: '80px', lg: '165px' } }}>
                 <AddressLink
-                    to={`${transaction.hash}`}
+                    to={`${CTRANSACTION}/${transaction.hash}`}
                     value={transaction.hash}
                     typographyVariant="body2"
                     truncate={true}

--- a/src/app/pages/CChainPages/Transactions/TransactionDetails.tsx
+++ b/src/app/pages/CChainPages/Transactions/TransactionDetails.tsx
@@ -23,7 +23,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { Status } from 'types'
 import { mdiTransfer } from '@mdi/js'
 import { mdiChevronRight, mdiChevronLeft } from '@mdi/js'
-import { CCHAIN, CTRANSACTIONS } from 'utils/route-paths'
+import { CCHAIN, CTRANSACTION } from 'utils/route-paths'
 import PageContainer from 'app/components/PageContainer'
 import BackButton from 'app/components/BackButton'
 import OutlinedContainer from 'app/components/OutlinedContainer'
@@ -83,7 +83,7 @@ const TransactionDetails: FC = () => {
             nextPrevTX[currentIndex] &&
             getTransactionFromUrl() !== nextPrevTX[currentIndex]?.hash
         )
-            navigate(`${CTRANSACTIONS}/${nextPrevTX[currentIndex]?.hash}`)
+            navigate(`${CTRANSACTION}/${nextPrevTX[currentIndex]?.hash}`)
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentIndex])
 

--- a/src/app/pages/XChainPages/Address/AddressSection.tsx
+++ b/src/app/pages/XChainPages/Address/AddressSection.tsx
@@ -3,6 +3,7 @@ import { Grid, Box, Chip } from '@mui/material'
 import AddressLink from 'app/components/AddressLink'
 import moment from 'utils/helpers/moment'
 import { getAddressFromUrl } from 'utils/route-utils'
+import { BASE_PATH, TRANSACTION } from 'utils/route-paths'
 
 export const AddressSection = ({ type, timestamp, id, chainType }) => {
     return (
@@ -10,7 +11,7 @@ export const AddressSection = ({ type, timestamp, id, chainType }) => {
             <Grid container item xs={12} lg={6} alignItems="center" justifyContent="center">
                 <Grid item xs={12}>
                     <AddressLink
-                        to={`/explorer/${chainType}/transactions/${id}`}
+                        to={`${BASE_PATH}/${chainType}${TRANSACTION}/${id}`}
                         value={id}
                         typographyVariant="subtitle1"
                         truncate={true}
@@ -47,7 +48,11 @@ export const AddressSection = ({ type, timestamp, id, chainType }) => {
                     <Chip
                         label={type}
                         size="small"
-                        style={{ minWidth: '61px', height: 'min-content' }}
+                        style={{
+                            minWidth: '61px',
+                            height: 'min-content',
+                            backgroundColor: '#334155',
+                        }}
                     />
                 </Grid>
             </Grid>

--- a/src/app/pages/XChainPages/Transactions/Transaction.tsx
+++ b/src/app/pages/XChainPages/Transactions/Transaction.tsx
@@ -136,7 +136,7 @@ const GridItem = ({ transaction }) => {
                 <Chip
                     label={transaction.type}
                     size="small"
-                    style={{ minWidth: '61px', height: 'min-content' }}
+                    style={{ minWidth: '61px', height: 'min-content', backgroundColor: '#334155' }}
                 />
             </Grid>
             <Grid item xs={12} md zeroMinWidth order={{ xs: 3, md: 2 }}>
@@ -219,7 +219,7 @@ const CustomRow = ({ transaction }) => {
                 <Chip
                     label={transaction.type}
                     size="small"
-                    style={{ minWidth: '61px', height: 'min-content' }}
+                    style={{ minWidth: '61px', height: 'min-content', backgroundColor: '#334155' }}
                 />
             </TableCell>
             <TableCell align="left" width="15%">

--- a/src/app/pages/XChainPages/Transactions/XPTransactionsDetails.tsx
+++ b/src/app/pages/XChainPages/Transactions/XPTransactionsDetails.tsx
@@ -14,6 +14,7 @@ import { transactionApi } from 'utils/magellan-api-utils'
 import { useAppSelector } from 'store/configureStore'
 import { selectMagellanAddress } from 'store/app-config'
 import { getChainTypeFromUrl, getAddressFromUrl } from 'utils/route-utils'
+import { BASE_PATH } from 'utils/route-paths'
 
 export default function XPTransactionDetails() {
     const [result, setResult] = React.useState<XPTransaction>()
@@ -80,7 +81,7 @@ export default function XPTransactionDetails() {
                             gap: '20px',
                         }}
                     >
-                        <BackButton backToLink={`/explorer/${getChainTypeFromUrl()}`} />
+                        <BackButton backToLink={`${BASE_PATH}/${getChainTypeFromUrl()}`} />
                         <Typography variant="h5" component="h5" fontWeight="fontWeightBold">
                             {`${location.pathname
                                 .split('/')[2][0]
@@ -98,7 +99,7 @@ export default function XPTransactionDetails() {
                 </Grid>
                 {details && (
                     <Box sx={{ display: 'flex', width: '100%', paddingTop: '1rem' }}>
-                        <BackButton backToLink={`/explorer/${getChainTypeFromUrl()}`} />
+                        <BackButton backToLink={`${BASE_PATH}/${getChainTypeFromUrl()}`} />
                     </Box>
                 )}
             </Paper>

--- a/src/utils/route-paths.ts
+++ b/src/utils/route-paths.ts
@@ -8,23 +8,41 @@ export const PCHAIN = BASE_PATH + '/p-chain'
 
 export const MAINNET = BASE_PATH + '/mainnet'
 
-export const CTRANSACTIONS = CCHAIN + '/transactions'
+export const TRANSACTION = '/tx'
 
-export const CBLOCKS = CCHAIN + '/blocks'
+export const BLOCK = '/block'
 
-export const CADDRESS = CCHAIN + '/address'
+export const ADDRESS = '/address'
 
-export const XTRANSACTIONS = XCHAIN + '/transactions'
+export const DETAILS = '/details'
 
-export const XBLOCKS = XCHAIN + '/blocks'
+export const BLOCKS = '/blocks'
 
-export const XADDRESS = XCHAIN + '/address'
+export const TRANSACTIONS = '/txs'
 
-export const PTRANSACTIONS = PCHAIN + '/transactions'
+export const CTRANSACTION = CCHAIN + TRANSACTION
 
-export const PBLOCKS = PCHAIN + '/blocks'
+export const CTRANSACTIONS = CCHAIN + TRANSACTIONS
 
-export const PADDRESS = PCHAIN + '/address'
+export const CBLOCKS = CCHAIN + BLOCK
+
+export const CADDRESS = CCHAIN + ADDRESS
+
+export const XTRANSACTION = XCHAIN + TRANSACTION
+
+export const XTRANSACTIONS = XCHAIN + TRANSACTIONS
+
+export const XBLOCKS = XCHAIN + BLOCK
+
+export const XADDRESS = XCHAIN + ADDRESS
+
+export const PTRANSACTION = PCHAIN + TRANSACTION
+
+export const PTRANSACTIONS = PCHAIN + TRANSACTIONS
+
+export const PBLOCKS = PCHAIN + BLOCK
+
+export const PADDRESS = PCHAIN + ADDRESS
 
 export const VALIDATORS = BASE_PATH + '/validators'
 

--- a/src/utils/route-utils.ts
+++ b/src/utils/route-utils.ts
@@ -1,20 +1,20 @@
 import { ChainType } from './types/chain-type'
-import { XADDRESS, PADDRESS, XTRANSACTIONS, PTRANSACTIONS } from 'utils/route-paths'
-
-export const DETAILS = 'details'
-export const TABLES = 'all'
-
-const transactions = 'transactions'
-const blocks = 'blocks'
-const address = 'address'
-const validators = 'validators'
+import {
+    XADDRESS,
+    PADDRESS,
+    XTRANSACTION,
+    PTRANSACTION,
+    TRANSACTION,
+    BLOCK,
+    ADDRESS,
+} from './route-paths'
 
 export function getPathElement(type: ChainType): string {
     return type.toLowerCase()
 }
 
 export function getTransactionDetailsPath(chaintype: ChainType, transactionId: string): string {
-    const basePath = `/${getPathElement(chaintype)}/${transactions}/`
+    const basePath = `/${getPathElement(chaintype)}${TRANSACTION}/`
     if (transactionId) {
         return basePath + transactionId
     }
@@ -22,43 +22,15 @@ export function getTransactionDetailsPath(chaintype: ChainType, transactionId: s
 }
 
 export function getAddressDetailsPath(chaintype: ChainType, addressId: string): string {
-    return `/${getPathElement(chaintype)}/${address}/${addressId}`
+    return `/${getPathElement(chaintype)}${ADDRESS}/${addressId}`
 }
 
 export function getBlockDetailsPath(chaintype: ChainType, blockId: string | number): string {
-    const basePath = `/${getPathElement(chaintype)}/${blocks}/`
+    const basePath = `/${getPathElement(chaintype)}${BLOCK}/`
     if (blockId !== undefined) {
         return basePath + blockId
     }
     return basePath
-}
-
-export function getAllBlocksPath(chaintype: ChainType) {
-    return `/${TABLES}/${getPathElement(chaintype)}/${blocks}`
-}
-
-export function getAllTransactionsPath(chaintype: ChainType) {
-    return `/${TABLES}/${getPathElement(chaintype)}/${transactions}`
-}
-
-export function getAllValidatorsPath() {
-    return `/${TABLES}/${validators}`
-}
-
-export function getTransactionsPathName(chaintype: ChainType) {
-    return `${chaintype}-${transactions}-${DETAILS}`
-}
-
-export function getBlockDetailsPathName(chaintype: ChainType) {
-    return `${chaintype}-${blocks}-${DETAILS}`
-}
-
-export function getAllBlocksPathName(chaintype: ChainType) {
-    return `${chaintype}-${blocks}-${TABLES}`
-}
-
-export function getAllTransactionsPathName(chaintype: ChainType) {
-    return `${chaintype}-${transactions}-${TABLES}`
 }
 
 export function getAddressLink(chaintype: ChainType, value: string): string {
@@ -98,11 +70,11 @@ export function getChainTypeFromUrl(): ChainType {
 export function getTransactionType(chainType) {
     switch (chainType) {
         case ChainType.X_CHAIN:
-            return XTRANSACTIONS
+            return XTRANSACTION
         case ChainType.P_CHAIN:
-            return PTRANSACTIONS
+            return PTRANSACTION
         default:
-            return XTRANSACTIONS
+            return XTRANSACTION
     }
 }
 


### PR DESCRIPTION
Updates the block explorer routing system to align with the EIP-3091 standard for Ethereum-based BEs. The new structure and syntax are: 

- `/tx/:hash` for transaction detail
- `/block/:id` for block detail
- `/txs` for all transaction
- `/blocks` for all blocks