### PR TITLE
remove decimals in map statistics

### DIFF
--- a/src/app/components/ValidatorsMap/Statistics.tsx
+++ b/src/app/components/ValidatorsMap/Statistics.tsx
@@ -24,7 +24,7 @@ const Statistics = ({ nodesPerCountry, darkMode }) => {
             lineColor: 'transparent',
             gridLineColor: '#666666',
             title: '',
-            allowDecimals: false
+            allowDecimals: false,
         },
         xAxis: {
             lineColor: 'transparent',
@@ -41,7 +41,7 @@ const Statistics = ({ nodesPerCountry, darkMode }) => {
                     )}" /> ${obj.value}</span>`
                 },
             },
-            allowDecimals: false
+            allowDecimals: false,
         },
 
         legend: {

--- a/src/app/components/ValidatorsMap/Statistics.tsx
+++ b/src/app/components/ValidatorsMap/Statistics.tsx
@@ -24,6 +24,7 @@ const Statistics = ({ nodesPerCountry, darkMode }) => {
             lineColor: 'transparent',
             gridLineColor: '#666666',
             title: '',
+            allowDecimals: false
         },
         xAxis: {
             lineColor: 'transparent',
@@ -40,6 +41,7 @@ const Statistics = ({ nodesPerCountry, darkMode }) => {
                     )}" /> ${obj.value}</span>`
                 },
             },
+            allowDecimals: false
         },
 
         legend: {


### PR DESCRIPTION
The display of decimals in the Map Statistics was removed, this in case there are few active validators on the Map