### PR TITLE
Default date co2emissions

### DIFF
--- a/src/app/components/Statistics/BlockchainDataCharts/LinearMeter.tsx
+++ b/src/app/components/Statistics/BlockchainDataCharts/LinearMeter.tsx
@@ -9,9 +9,9 @@ const LinearMeter = ({ darkMode, titleText, data, typeStatistic, timeSeeAxis }) 
     if (config.data !== undefined && config.data != null) {
         const options = {
             title: {
-                text: '',
+                text: titleText,
                 style: {
-                    color: darkMode ? 'white' : 'black',
+                    display: 'none',
                 },
             },
             chart: {

--- a/src/app/components/Statistics/BlockchainDataCharts/index.tsx
+++ b/src/app/components/Statistics/BlockchainDataCharts/index.tsx
@@ -22,6 +22,7 @@ import styled from 'styled-components'
 import { Grid, useTheme } from '@mui/material'
 import moment from 'moment'
 import { TextBlockchainDatachart } from '../../../../utils/statistics/TextBlockchainDatachart'
+import '../../../../styles/scrollbarModal.css'
 
 const TooltipContainer = styled.div`
     display: flex;
@@ -173,7 +174,7 @@ const BlockchainCharts = ({
                     sx={{
                         backgroundColor: 'transparent',
                         borderRadius: '7px',
-                        padding: '1.5rem',
+                        padding: 0,
                         width: isWidescreen ? '1300px' : '80%',
                     }}
                     style={{
@@ -181,7 +182,7 @@ const BlockchainCharts = ({
                         overflowY: 'auto',
                     }}
                 >
-                    <Card style={{ backgroundColor: darkMode ? '#060F24' : 'white' }}>
+                    <Card style={{ backgroundColor: darkMode ? '#060F24' : 'white', position:'relative', width:'100%' }}>
                         <CardHeader
                             title={titleText}
                             action={

--- a/src/app/components/Statistics/BlockchainDataCharts/index.tsx
+++ b/src/app/components/Statistics/BlockchainDataCharts/index.tsx
@@ -178,11 +178,17 @@ const BlockchainCharts = ({
                         width: isWidescreen ? '1300px' : '80%',
                     }}
                     style={{
-                        maxHeight: isSmallMobile ? 550 : '80%',
+                        maxHeight: isSmallMobile ? 550 : '90%',
                         overflowY: 'auto',
                     }}
                 >
-                    <Card style={{ backgroundColor: darkMode ? '#060F24' : 'white', position:'relative', width:'100%' }}>
+                    <Card
+                        style={{
+                            backgroundColor: darkMode ? '#060F24' : 'white',
+                            position: 'relative',
+                            width: '100%',
+                        }}
+                    >
                         <CardHeader
                             title={titleText}
                             action={

--- a/src/app/components/Statistics/CO2ConsumptionCharts/CountriesBarMeter.tsx
+++ b/src/app/components/Statistics/CO2ConsumptionCharts/CountriesBarMeter.tsx
@@ -26,7 +26,7 @@ const CountriesBarMeter = ({ darkMode, titleText, dataSeries }) => {
         },
         title: {
             align: 'left',
-            text: titleText,
+            text: '',
             style: {
                 color: darkMode ? 'white' : 'black',
             },

--- a/src/app/components/Statistics/CO2ConsumptionCharts/TimeSeriesMeter.tsx
+++ b/src/app/components/Statistics/CO2ConsumptionCharts/TimeSeriesMeter.tsx
@@ -14,9 +14,9 @@ const TimeSeriesMeter = ({ dataSeries, darkMode, titleText, seeTimeAxis }) => {
                 backgroundColor: 'rgba(0,0,0,0)',
             },
             title: {
-                text: '',
+                text: titleText,
                 style: {
-                    color: darkMode ? 'white' : 'black',
+                    display: 'none',
                 },
             },
             yAxis: {

--- a/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
+++ b/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
@@ -23,8 +23,8 @@ import { mdiClose } from '@mdi/js'
 import { useTheme } from '@mui/material'
 
 type DatesChart = {
-    starterDate: any
-    endingDate: any
+    starterDate: Date
+    endingDate: Date
 }
 
 const TooltipContainer = styled.div`

--- a/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
+++ b/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
@@ -52,7 +52,7 @@ const CO2ConsumptionCharts = ({
     const theme = useTheme()
     const isDark = theme.palette.mode === 'dark'
 
-    const { isWidescreen } = useWidth()
+    const { isSmallMobile, isWidescreen } = useWidth()
 
     const [openModal, setOpenModal] = useState(false)
     const [startDate, setStartDate] = useState<Date>()
@@ -117,7 +117,9 @@ const CO2ConsumptionCharts = ({
 
     function CO2EmissionsDate(): DatesChart {
         let datesChart: DatesChart = {
+            // @ts-ignore
             starterDate: startDate,
+            // @ts-ignore
             endingDate: endDate,
         }
 
@@ -220,6 +222,7 @@ const CO2ConsumptionCharts = ({
                                 minWidth: isWidescreen ? '1300px' : '0px',
                             }}
                             style={{
+                                maxHeight: isSmallMobile ? 550 : '90%',
                                 overflowY: 'auto',
                             }}
                         >

--- a/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
+++ b/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
@@ -21,6 +21,7 @@ import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward'
 import Icon from '@mdi/react'
 import { mdiClose } from '@mdi/js'
 import { useTheme } from '@mui/material'
+import '../../../../styles/scrollbarModal.css'
 
 type DatesChart = {
     starterDate: any
@@ -215,7 +216,7 @@ const CO2ConsumptionCharts = ({
                             sx={{
                                 backgroundColor: 'transparent',
                                 borderRadius: '7px',
-                                padding: '1.5rem',
+                                padding: 0,
                                 minWidth: isWidescreen ? '1300px' : '0px',
                             }}
                             style={{

--- a/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
+++ b/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
@@ -64,13 +64,7 @@ const CO2ConsumptionCharts = ({
 
     useEffect(() => {
         if (startDate !== undefined && endDate !== undefined) {
-            //CO2EmissionsDate()
-            dispatch(
-                utilSlice({
-                    startDate: `${moment(startDate).format('YYYY-MM-DD')}T00:00:00Z`,
-                    endDate: `${moment(endDate).format('YYYY-MM-DD')}T23:59:59Z`,
-                }),
-            )
+            CO2EmissionsDate()
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [startDate, endDate])
@@ -121,10 +115,25 @@ const CO2ConsumptionCharts = ({
     }
 
     function CO2EmissionsDate(): DatesChart {
-        return {
+        let datesChart: DatesChart = {
             starterDate: startDate,
             endingDate: endDate,
         }
+
+        let diffDays = moment(datesChart.endingDate).diff(moment(datesChart.starterDate), 'days')
+
+        if (diffDays <= 0) {
+            let newStarterDate = moment(datesChart.endingDate).add(-1, 'days').toDate()
+            setStartDate(newStarterDate)
+        } else {
+            dispatch(
+                utilSlice({
+                    startDate: `${moment(startDate).format('YYYY-MM-DD')}T00:00:00Z`,
+                    endDate: `${moment(endDate).format('YYYY-MM-DD')}T23:59:59Z`,
+                }),
+            )
+        }
+        return datesChart
     }
 
     return (

--- a/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
+++ b/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
@@ -22,6 +22,11 @@ import Icon from '@mdi/react'
 import { mdiClose } from '@mdi/js'
 import { useTheme } from '@mui/material'
 
+type DatesChart = {
+    starterDate: any
+    endingDate: any
+}
+
 const TooltipContainer = styled.div`
     display: flex;
     padding-top: 2rem;
@@ -59,6 +64,7 @@ const CO2ConsumptionCharts = ({
 
     useEffect(() => {
         if (startDate !== undefined && endDate !== undefined) {
+            //CO2EmissionsDate()
             dispatch(
                 utilSlice({
                     startDate: `${moment(startDate).format('YYYY-MM-DD')}T00:00:00Z`,
@@ -70,8 +76,7 @@ const CO2ConsumptionCharts = ({
     }, [startDate, endDate])
 
     useEffect(() => {
-        setStartDate(new Date(moment().startOf('month').format('YYYY-MM-DD HH:mm:ss')))
-        setEndDate(new Date(moment().endOf('day').format('YYYY-MM-DD HH:mm:ss')))
+        defaultDatesCO2Emissions()
     }, [])
 
     const meterCO2: any = useAppSelector(sliceGetter)
@@ -83,6 +88,44 @@ const CO2ConsumptionCharts = ({
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [meterCO2])
+
+    function defaultDatesCO2Emissions() {
+        let todayDay = new Date().getDate()
+
+        //First 5 days of Month
+        if (todayDay <= 5) {
+            setStartDate(
+                new Date(
+                    moment()
+                        .add(-7, 'days')
+                        .startOf('month')
+                        .startOf('day')
+                        .format('YYYY-MM-DD HH:mm:ss'),
+                ),
+            )
+            setEndDate(
+                new Date(
+                    moment()
+                        .add(-7, 'days')
+                        .endOf('month')
+                        .endOf('day')
+                        .format('YYYY-MM-DD HH:mm:ss'),
+                ),
+            )
+        } else {
+            setStartDate(
+                new Date(moment().startOf('month').startOf('day').format('YYYY-MM-DD HH:mm:ss')),
+            )
+            setEndDate(new Date(moment().endOf('month').endOf('day').format('YYYY-MM-DD HH:mm:ss')))
+        }
+    }
+
+    function CO2EmissionsDate(): DatesChart {
+        return {
+            starterDate: startDate,
+            endingDate: endDate,
+        }
+    }
 
     return (
         <Fragment>

--- a/src/app/components/Statistics/ChartConfig/ChartConfig.ts
+++ b/src/app/components/Statistics/ChartConfig/ChartConfig.ts
@@ -141,7 +141,7 @@ class ChartConfig {
             }
         }
         if (
-            highestDate.getDay() === lowestDate.getDay() &&
+            highestDate.getDate() === lowestDate.getDate() &&
             highestDate.getMonth() === lowestDate.getMonth() &&
             highestDate.getFullYear() === lowestDate.getFullYear()
         ) {

--- a/src/app/components/Statistics/DateRange/DateRange.tsx
+++ b/src/app/components/Statistics/DateRange/DateRange.tsx
@@ -137,7 +137,7 @@ const DateRange = ({
     ))
 
     const getMaxDate = (isStartDate: boolean) => {
-        if (InitianEndDate != null && InitianEndDate !== undefined && isStartDate === true) {
+        if (InitianEndDate !== null && InitianEndDate !== undefined && isStartDate === true) {
             return InitianEndDate
         }
 

--- a/src/app/components/Statistics/DateRange/DateRange.tsx
+++ b/src/app/components/Statistics/DateRange/DateRange.tsx
@@ -136,7 +136,11 @@ const DateRange = ({
         </CustomInputContainer>
     ))
 
-    const getMaxDate = () => {
+    const getMaxDate = (isStartDate: boolean) => {
+        if (InitianEndDate != null && InitianEndDate !== undefined && isStartDate === true) {
+            return InitianEndDate
+        }
+
         if (disableFuture) {
             return new Date()
         }
@@ -245,7 +249,7 @@ const DateRange = ({
                             startDate={initialStartDate}
                             endDate={InitianEndDate}
                             customInput={<CustomInput label="Initial Date" />}
-                            maxDate={getMaxDate()}
+                            maxDate={getMaxDate(true)}
                             // readOnly
                         />
                         <DatePicker
@@ -256,7 +260,7 @@ const DateRange = ({
                             endDate={InitianEndDate}
                             minDate={initialStartDate}
                             customInput={<CustomInput label="End Date" />}
-                            maxDate={getMaxDate()}
+                            maxDate={getMaxDate(false)}
                             // readOnly
                         />
                     </PickerContainer>
@@ -334,7 +338,7 @@ const DateRange = ({
                         </RadioGroup>
                     </FormControl>
                     <br />
-                    <FilterContainerMobile>
+                    <FilterContainerMobile className={darkMode ? 'picker-container' : ''}>
                         <DatePicker
                             selected={initialStartDate}
                             onChange={date => setStartDate(date)}
@@ -342,6 +346,8 @@ const DateRange = ({
                             startDate={initialStartDate}
                             endDate={InitianEndDate}
                             customInput={<CustomInputMobile label="Initial Date" />}
+                            maxDate={getMaxDate(true)}
+                            withPortal
                             // readOnly
                         />
                         <DatePicker
@@ -352,6 +358,8 @@ const DateRange = ({
                             endDate={InitianEndDate}
                             minDate={initialStartDate}
                             customInput={<CustomInputMobile label="End Date" />}
+                            maxDate={getMaxDate(false)}
+                            withPortal
                             // readOnly
                         />
                     </FilterContainerMobile>

--- a/src/app/components/Statistics/DateRange/DateRange.tsx
+++ b/src/app/components/Statistics/DateRange/DateRange.tsx
@@ -73,7 +73,7 @@ const DateRange = ({
         setSeeTimeAxis('year')
         setStartDate(new Date(moment().startOf('year').format('YYYY-MM-DD HH:mm:ss')))
 
-        if (!disableFuture) {
+        if (disableFuture) {
             setEndDate(new Date(moment().endOf('day').format('YYYY-MM-DD HH:mm:ss')))
         } else {
             setEndDate(new Date(moment().endOf('year').format('YYYY-MM-DD HH:mm:ss')))

--- a/src/styles/custompicker.css
+++ b/src/styles/custompicker.css
@@ -17,3 +17,8 @@
 .picker-container .react-datepicker__day-name {
     color: white;
 }
+
+.picker-container .react-datepicker__day--disabled, 
+.react-datepicker__month-text--disabled, .react-datepicker__quarter-text--disabled, .react-datepicker__year-text--disabled{
+    color: rgb(133, 133, 133) !important;
+}

--- a/src/styles/scrollbarModal.css
+++ b/src/styles/scrollbarModal.css
@@ -1,0 +1,21 @@
+/* width */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+/* Track */
+/* ::-webkit-scrollbar-track {
+    box-shadow: inset 0 0 5px grey;
+    border-radius: 10px;
+} */
+
+/* Handle */
+::-webkit-scrollbar-thumb {
+    background: #0f2557;
+    border-radius: 10px;
+}
+
+/* Handle on hover */
+::-webkit-scrollbar-thumb:hover {
+    background: #1e49ae;
+}

--- a/src/styles/scrollbarModal.css
+++ b/src/styles/scrollbarModal.css
@@ -3,12 +3,6 @@
     width: 8px;
 }
 
-/* Track */
-/* ::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 5px grey;
-    border-radius: 10px;
-} */
-
 /* Handle */
 ::-webkit-scrollbar-thumb {
     background: #acacac;

--- a/src/styles/scrollbarModal.css
+++ b/src/styles/scrollbarModal.css
@@ -11,11 +11,11 @@
 
 /* Handle */
 ::-webkit-scrollbar-thumb {
-    background: #0f2557;
+    background: #acacac;
     border-radius: 10px;
 }
 
 /* Handle on hover */
 ::-webkit-scrollbar-thumb:hover {
-    background: #1e49ae;
+    background: #d8d8d8;
 }


### PR DESCRIPTION
-Avoid dates greater than the end date in the start date filter
-CO2 Emissions default date is from the previous month if it is within the first 5 days of the current month.
-CO2 Emissions per day also takes a previous day (This is due to CO2 Emissions API problems, at least for now)
-Mobile date picker