### PR TITLE
add text and tooltip in co2 emissions charts

### DIFF
--- a/src/app/components/Statistics/BlockchainDataCharts/index.tsx
+++ b/src/app/components/Statistics/BlockchainDataCharts/index.tsx
@@ -45,10 +45,10 @@ interface TextProps {
 }
 
 const Text = styled('p')<TextProps>`
-    margin-left: 3rem !important;
-    margin-right: 1rem !important;
-    margin-top: 0.5rem !important;
-    margin-bottom: 0.5rem !important;
+    margin-left: 3rem;
+    margin-right: 1rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
     border-radius: 0.5rem;
     background: ${({ backgroundColor }) => backgroundColor};
     padding: 0.5rem;

--- a/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
+++ b/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
@@ -49,10 +49,10 @@ interface TextProps {
 }
 
 const Text = styled('p')<TextProps>`
-    margin-left: 3rem !important;
-    margin-right: 1rem !important;
-    margin-top: 0.5rem !important;
-    margin-bottom: 0.5rem !important;
+    margin-left: 3rem;
+    margin-right: 1rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
     border-radius: 0.5rem;
     background: ${({ backgroundColor }) => backgroundColor};
     padding: 0.5rem;

--- a/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
+++ b/src/app/components/Statistics/CO2ConsumptionCharts/index.tsx
@@ -20,9 +20,11 @@ import styled from 'styled-components'
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward'
 import Icon from '@mdi/react'
 import { mdiClose } from '@mdi/js'
-import { useTheme } from '@mui/material'
+import { useTheme, Grid } from '@mui/material'
 import '../../../../styles/scrollbarModal.css'
 import { ConsumptionCharts, Emissions } from 'types/statistics'
+import Tooltip from '@mui/material/Tooltip'
+import InfoIcon from '@mui/icons-material/Info'
 
 type DatesChart = {
     starterDate: Date
@@ -42,6 +44,20 @@ const DateRangeContainer = styled.div`
     }
 `
 
+interface TextProps {
+    backgroundColor: string
+}
+
+const Text = styled('p')<TextProps>`
+    margin-left: 3rem !important;
+    margin-right: 1rem !important;
+    margin-top: 0.5rem !important;
+    margin-bottom: 0.5rem !important;
+    border-radius: 0.5rem;
+    background: ${({ backgroundColor }) => backgroundColor};
+    padding: 0.5rem;
+`
+
 const CO2ConsumptionCharts = ({
     utilSlice,
     typeMeter,
@@ -49,6 +65,7 @@ const CO2ConsumptionCharts = ({
     sliceGetter,
     sliceGetterLoader,
     titleText,
+    description,
 }: ConsumptionCharts) => {
     const theme = useTheme()
     const isDark = theme.palette.mode === 'dark'
@@ -155,7 +172,16 @@ const CO2ConsumptionCharts = ({
                 <>
                     <Card style={{ backgroundColor: darkMode ? '#060F24' : 'white' }}>
                         <CardHeader
-                            title={titleText}
+                            title={
+                                <span>
+                                    {titleText}
+                                    <Tooltip title={description} placement="top">
+                                        <IconButton>
+                                            <InfoIcon />
+                                        </IconButton>
+                                    </Tooltip>
+                                </span>
+                            }
                             style={{
                                 marginBottom: '0rem',
                                 marginLeft: '0.5rem',
@@ -248,6 +274,18 @@ const CO2ConsumptionCharts = ({
                                     }
                                 />
                                 <CardContent>
+                                    <Grid
+                                        container
+                                        spacing={2}
+                                        justifyContent="center"
+                                        alignItems="center"
+                                    >
+                                        <Grid item xs={12}>
+                                            <Text backgroundColor={isDark ? '#0f172a' : '#F5F6FA'}>
+                                                {description}
+                                            </Text>
+                                        </Grid>
+                                    </Grid>
                                     {meterCO2 != null && meterCO2 !== undefined && (
                                         <DateRangeContainer>
                                             <DateRange

--- a/src/app/pages/Statistics/index.tsx
+++ b/src/app/pages/Statistics/index.tsx
@@ -56,6 +56,9 @@ const Statistics: FC = () => {
     const theme = useTheme()
     const dark = theme.palette.mode === 'light' ? false : true
 
+    let descriptionDefaultCO2 =
+        'The CO2 emissions shown are summarized of both the Camino and the Columbus network. Moreover, if a particular network is selected, the CO2 emissions will be displayed collectively.'
+
     return (
         <PageContainer pageTitle="Statistics" metaContent="statistics">
             <Paper
@@ -195,6 +198,7 @@ const Statistics: FC = () => {
                                 sliceGetter={getDailyEmissions}
                                 sliceGetterLoader={getDailyEmissionsStatus}
                                 titleText="Daily Emissions"
+                                description={descriptionDefaultCO2}
                             />
                         </Grid>
 
@@ -206,6 +210,7 @@ const Statistics: FC = () => {
                                 sliceGetter={getNetworkEmissions}
                                 sliceGetterLoader={getNetworkEmissionsStatus}
                                 titleText="Network Emissions"
+                                description={descriptionDefaultCO2}
                             />
                         </Grid>
 
@@ -217,6 +222,7 @@ const Statistics: FC = () => {
                                 sliceGetter={getTransactionsEmissions}
                                 sliceGetterLoader={getTransactionsEmissionsStatus}
                                 titleText="Network Emissions Per Transaction"
+                                description={descriptionDefaultCO2}
                             />
                         </Grid>
 
@@ -228,6 +234,7 @@ const Statistics: FC = () => {
                                 sliceGetter={getCountryEmissions}
                                 sliceGetterLoader={getCountryEmissionsStatus}
                                 titleText="Country Emissions"
+                                description={descriptionDefaultCO2}
                             />
                         </Grid>
                     </Grid>

--- a/src/types/statistics.ts
+++ b/src/types/statistics.ts
@@ -11,6 +11,7 @@ export interface ConsumptionCharts {
     sliceGetterLoader: (state: RootState) => string
     typeStatistic?: string
     tooltipTitle?: string
+    description?: string
 }
 
 export interface Meter {


### PR DESCRIPTION
CO2 stats will now have the following description:

The CO2 emissions shown are summarized of both the Camino and the Columbus network. Moreover, if a particular network is selected, the CO2 emissions will be displayed collectively.