### PR TITLE
Individual descriptions in the co2 charts

### DIFF
--- a/src/app/pages/Statistics/index.tsx
+++ b/src/app/pages/Statistics/index.tsx
@@ -57,9 +57,6 @@ const Statistics: FC = () => {
     const theme = useTheme()
     const dark = theme.palette.mode === 'light' ? false : true
 
-    let descriptionDefaultCO2 =
-        'The CO2 emissions shown are summarized of both the Camino and the Columbus network. Moreover, if a particular network is selected, the CO2 emissions will be displayed collectively.'
-
     return (
         <PageContainer pageTitle="Statistics" metaContent="statistics">
             <Paper
@@ -199,7 +196,9 @@ const Statistics: FC = () => {
                                 sliceGetter={getDailyEmissions}
                                 sliceGetterLoader={getDailyEmissionsStatus}
                                 titleText="Daily Emissions"
-                                description={descriptionDefaultCO2}
+                                description={
+                                    'The daily emissions chart shows the daily C02 emissions of the network compared to other popular blockchains.'
+                                }
                             />
                         </Grid>
 
@@ -211,7 +210,9 @@ const Statistics: FC = () => {
                                 sliceGetter={getNetworkEmissions}
                                 sliceGetterLoader={getNetworkEmissionsStatus}
                                 titleText="Network Emissions"
-                                description={descriptionDefaultCO2}
+                                description={
+                                    'The network emissions chart shows the C02 emissions of the network.'
+                                }
                             />
                         </Grid>
 
@@ -223,7 +224,9 @@ const Statistics: FC = () => {
                                 sliceGetter={getTransactionsEmissions}
                                 sliceGetterLoader={getTransactionsEmissionsStatus}
                                 titleText="Network Emissions Per Transaction"
-                                description={descriptionDefaultCO2}
+                                description={
+                                    'The network emissions per transaction chart shows the C02 emissions of each transaction.'
+                                }
                             />
                         </Grid>
 
@@ -235,7 +238,9 @@ const Statistics: FC = () => {
                                 sliceGetter={getCountryEmissions}
                                 sliceGetterLoader={getCountryEmissionsStatus}
                                 titleText="Country Emissions"
-                                description={descriptionDefaultCO2}
+                                description={
+                                    'The country emissions chart illustrates and compares the levels of CO2 emissions from six countries around the world that have high carbon dioxide emissions.'
+                                }
                             />
                         </Grid>
                     </Grid>


### PR DESCRIPTION
Removed the generic description for each of the CO2 graphs and instead each graph has its own description.