### PR TITLE
delete block time, new address seen, uncles count in Daily Transactions

### DIFF
--- a/src/app/components/Statistics/ChartConfig/Tooltips.ts
+++ b/src/app/components/Statistics/ChartConfig/Tooltips.ts
@@ -18,12 +18,8 @@ export const dailyTransactionsTooltip = (data: DailyTransactionsInfo) => {
         <br/>
         <br/>
 
-        <b>Avg Block Time:</b>${data.avgBlockTime}<br/>
         <b>Avg Block Size:</b>${data.avgBlockSize}<br/>
         <b>Total Block Count:</b>${data.totalBlockCount} <br/>
-        <b>Total Uncles Count:</b>${data.totalUnclesCount} <br/>
-        <b>New Adress Seen:</b>${data.newAddressSeen}
-        
         </span><br/>`
     return header
 }


### PR DESCRIPTION
Removed from Daily Transactions chart:
-Avg Block Time
-Total Uncles Count
-New Address Seen

The reason why they eliminate these 3 statistics is because the information is not yet obtained in the magellan.