### PR TITLE
change text weis to gweis

### DIFF
--- a/src/app/components/Statistics/ChartConfig/ChartConfig.ts
+++ b/src/app/components/Statistics/ChartConfig/ChartConfig.ts
@@ -259,7 +259,7 @@ class ChartConfig {
                 })
             case typesStatistic.GAS_AVERAGE_PRICE:
                 return this.data.map((value: { avgGas: string; date: string }, index: number) => {
-                    return { y: value.avgGas, name: value.date }
+                    return { y: parseInt(value.avgGas)/1000000000, name: value.date }
                 })
             case typesStatistic.GAS_AVERAGE_LIMIT:
                 return this.data.map(

--- a/src/app/components/Statistics/ChartConfig/Tooltips.ts
+++ b/src/app/components/Statistics/ChartConfig/Tooltips.ts
@@ -80,7 +80,7 @@ export const averageGasPriceTooltip = (
     const header = `<span>
     ${moment(data.date, 'YYYY-MM-DD').format('MMMM Do YYYY')}
         <br/>
-        [<label style="color: blue">Average gas price:</label> <b>${data.avgGas} Gwei</b>]
+        [<label style="color: blue">Average gas price:</label> <b>${data.avgGas / 1000000000} Gwei</b>]
         <br/>
         <br/>
         <b>Max gas price:</b>${highestAndLowestInfo.highestValue} Gwei<br/>

--- a/src/app/pages/Statistics/index.tsx
+++ b/src/app/pages/Statistics/index.tsx
@@ -144,7 +144,7 @@ const Statistics: FC = () => {
                             <BlockchainCharts
                                 tooltipTitle="The Camino Average Gas Price Chart shows the daily average gas price, including the gas unit and gas tip used of the Camino Network."
                                 darkMode={dark}
-                                titleText={'Average gas price'}
+                                titleText={'Average gas price (Gweis)'}
                                 utilSlice={(dates: Date) => loadGasAveragePrice(dates)}
                                 sliceGetter={getGasAveragePrice}
                                 sliceGetterLoader={getGasAveragePriceInfo}


### PR DESCRIPTION
Now the Average Gas Price chart has the conversion in Gweis, since the data that was brought from the Magellan was in Weis.
The title of Average Gas Price was also changed to Average Gas Price (Gwei)