### PR TITLE
run cypress tests from camino-suite and in parallel

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,7 +11,7 @@ env:
   wallet_image: 'europe-west3-docker.pkg.dev/pwk-c4t-dev/camino-suite-apps/camino-suite-wallet'
 
 jobs:
-  build:
+  cypress-wallet:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -41,9 +41,9 @@ jobs:
           export SUITE_IMAGE=${{ env.suite_image }}:${{ steps.setBranch.outputs.branch }}
           export WALLET_IMAGE=${{ env.wallet_image }}:${{ steps.setBranch.outputs.branch }}
           docker-compose up -d
-          docker cp camino-suite-wallet-container:/app/camino-wallet ./
+          docker cp camino-suite-host-container:/app/camino-suite ./
           mkdir -p /home/runner/.cache
-          docker cp camino-suite-wallet-container:/root/.cache/Cypress  /home/runner/.cache/
+          docker cp camino-suite-host-container:/root/.cache/Cypress  /home/runner/.cache/
 
       - name: cypress-run
         uses: cypress-io/github-action@v5
@@ -51,12 +51,13 @@ jobs:
           USE_HTTP: true
         with:
           wait-on: 'http://localhost:5001/, http://localhost:5002/, http://localhost:5003/'
-          working-directory: camino-wallet
+          working-directory: camino-suite
           # wait for 3 minutes for the server to respond
           wait-on-timeout: 180
           browser: chrome
           headless: true
           config-file: cypress.config.ts
+          env: grepTags=@wallet
 
       # These extract all artifacts out from the container to git so they can be previewed
       - name: extract screenshots to git
@@ -64,11 +65,74 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots
-          path: camino-wallet/cypress/screenshots
+          path: camino-suite/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
       - name: extract videos to git
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-videos
-          path: camino-wallet/cypress/videos
+          path: camino-suite/cypress/videos
+
+  cypress-explorer:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # The node version, you can put one or many versions in here to test with
+        node: [16]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: get branch name
+        id: setBranch
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "branch=${{ github.base_ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+
+      - name: build local image
+        run: |
+          docker-compose build --build-arg SUITE_IMAGE=${{ env.suite_image }}:${{ steps.setBranch.outputs.branch }} --build-arg WALLET_IMAGE=${{ env.wallet_image }}:${{ steps.setBranch.outputs.branch }}
+          export SUITE_IMAGE=${{ env.suite_image }}:${{ steps.setBranch.outputs.branch }}
+          export WALLET_IMAGE=${{ env.wallet_image }}:${{ steps.setBranch.outputs.branch }}
+          docker-compose up -d
+          docker cp camino-suite-host-container:/app/camino-suite ./
+          mkdir -p /home/runner/.cache
+          docker cp camino-suite-host-container:/root/.cache/Cypress  /home/runner/.cache/
+
+      - name: cypress-run
+        uses: cypress-io/github-action@v5
+        env:
+          USE_HTTP: true
+        with:
+          wait-on: 'http://localhost:5001/, http://localhost:5002/, http://localhost:5003/'
+          working-directory: camino-suite
+          # wait for 3 minutes for the server to respond
+          wait-on-timeout: 180
+          browser: chrome
+          headless: true
+          config-file: cypress.config.ts
+          env: grepTags=@explorer
+
+      # These extract all artifacts out from the container to git so they can be previewed
+      - name: extract screenshots to git
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: camino-suite/cypress/screenshots
+      # Test run video was always captured, so this action uses "always()" condition
+      - name: extract videos to git
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cypress-videos
+          path: camino-suite/cypress/videos


### PR DESCRIPTION
- run cypress tests from camino-suite instead of camino-wallet
- run cypress tests for wallet and explorer in parallel