### PR TITLE
Add DAC Deployment and Update GitHub Actions

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 WALLET_IMAGE="europe-west3-docker.pkg.dev/pwk-c4t-dev/camino-suite-apps/camino-suite-wallet:suite"
 EXPLORER_IMAGE="explorer-local"
 SUITE_IMAGE="europe-west3-docker.pkg.dev/pwk-c4t-dev/camino-suite-apps/camino-suite-host:suite"
+VOTING_IMAGE="europe-west3-docker.pkg.dev/pwk-c4t-dev/camino-suite-apps/camino-suite-voting:suite"
 BUILD_ENV="build:dev"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -61,17 +61,17 @@ jobs:
 
       # These extract all artifacts out from the container to git so they can be previewed
       - name: extract screenshots to git
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-screenshots
+          name: cypress-screenshots_wallet
           path: camino-suite/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
       - name: extract videos to git
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cypress-videos
+          name: cypress-videos_wallet
           path: camino-suite/cypress/videos
 
   cypress-explorer:
@@ -124,15 +124,15 @@ jobs:
 
       # These extract all artifacts out from the container to git so they can be previewed
       - name: extract screenshots to git
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-screenshots
-          path: camino-suite/cypress/screenshots
+          name: cypress-screenshots_explorer
+          path: camino-suite/cypress/screenshots_explorer
       # Test run video was always captured, so this action uses "always()" condition
       - name: extract videos to git
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cypress-videos
+          name: cypress-videos_explorer
           path: camino-suite/cypress/videos

--- a/Dockerfile_SUITE
+++ b/Dockerfile_SUITE
@@ -1,6 +1,7 @@
 ARG BUILD_ENV="build:dev"
 ARG SUITE_BRANCH=suite
 ARG WALLET_BRANCH=suite
+ARG VOTING_BRANCH=suite
 
 FROM node:16 as stage-explorer
 ARG BUILD_ENV
@@ -16,11 +17,14 @@ FROM europe-west3-docker.pkg.dev/pwk-c4t-dev/camino-suite-apps/camino-suite-host
 
 FROM europe-west3-docker.pkg.dev/pwk-c4t-dev/camino-suite-apps/camino-suite-wallet:$WALLET_BRANCH  as stage-wallet
 
+FROM europe-west3-docker.pkg.dev/pwk-c4t-dev/camino-suite-apps/camino-suite-voting:$VOTING_BRANCH  as stage-voting
+
 
 
 FROM nginx:1.18
 COPY --from=stage-suite /app/camino-suite/dist/ /usr/share/nginx/html
 COPY --from=stage-explorer /app/camino-block-explorer/dist/ /usr/share/nginx/html/explorer
 COPY --from=stage-wallet /app/camino-wallet/dist/ /usr/share/nginx/html/wallet
+COPY --from=stage-voting /app/camino-suite-voting/dist/ /usr/share/nginx/html/dac
 # Copy the default nginx.conf provided by tiangolo/node-frontend
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,12 @@ version: '3.5'
 
 services:
 
+  voting:
+    image: ${VOTING_IMAGE}
+    entrypoint: ["yarn", "start"]
+    ports:
+      - 5004:5004
+    container_name: camino-suite-voting-container
   wallet:
     image: ${WALLET_IMAGE}
     entrypoint: ["yarn", "start"]


### PR DESCRIPTION
This PR introduces DAC deployment support and enhances CI/CD workflows with updated GitHub Actions.

Features
	•	Add DAC Deployment:
	•	Implemented deployment logic for DAC, enabling streamlined deployment processes.

DevOps
	•	GitHub Actions Update:
	•	Updated the upload-artifact action to version 4 for improved performance and compatibility.