### PR TITLE
fix(explorer): render c-chain page when no network is provided in URL

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -11,14 +11,10 @@ import { ComingSoonPage } from './pages/ComingSoon'
 import { TransactionDetails, BlockDetails } from './pages/CChainPages'
 import XPTransactionDetails from './pages/XChainPages/Transactions/XPTransactionsDetails'
 import Validators from './pages/Validators'
-import NotFoundPage from './pages/PageNotFound'
 import { RoutesConfig } from '../utils/route-paths'
 import Statistics from './pages/Statistics'
-import { getActiveNetwork } from 'store/app-config'
-import { useAppSelector } from 'store/configureStore'
 
 export function App() {
-    let activeNetwork = useAppSelector(getActiveNetwork)
     let routesConfig = RoutesConfig()
 
     return (
@@ -31,54 +27,54 @@ export function App() {
                 >
                     <meta name="description" content="Camino Block Explorer" />
                 </Helmet>
-                {activeNetwork ? (
-                    <Routes>
-                        <Route path={`${routesConfig.BASE_PATH}`} element={<MainLayout />}>
-                            <Route
-                                path={`${routesConfig.BASE_PATH}`}
-                                element={
-                                    <Navigate
-                                        replace={true}
-                                        to={`${routesConfig.BASE_PATH}/c-chain`}
-                                    />
-                                }
-                            />
-                            <Route path="c-chain">
-                                <Route index element={<CChainPage />} />
-                                <Route path="blocks" element={<Blocks />} />
-                                <Route path="txs" element={<CTransactions />} />
-                                <Route path="block/:id" element={<BlockDetails />} />
-                                <Route path="tx/:id" element={<TransactionDetails />} />
-                                <Route path="address/:id" element={<Address />} />
-                            </Route>
-                            <Route path="x-chain">
-                                <Route index element={<XChainPage />} />
-                                <Route path="txs" element={<XPTransactions />} />
-                                <Route path="tx/:id" element={<XPTransactionDetails />} />
-                                <Route path="address/:id" element={<XAddressDetail />} />
-                            </Route>
-                            <Route path="p-chain">
-                                <Route index element={<PChainPage />} />
-                                <Route path="txs" element={<XPTransactions />} />
-                                <Route path="tx/:id" element={<XPTransactionDetails />} />
-                                <Route path="address/:id" element={<XAddressDetail />} />
-                            </Route>
-                            <Route
-                                path={`${routesConfig.BASE_PATH}/mainnet`}
-                                element={<ComingSoonPage />}
-                            />
-                            <Route
-                                path={`${routesConfig.BASE_PATH}/validators`}
-                                element={<Validators />}
-                            />
-                            <Route
-                                path={`${routesConfig.BASE_PATH}/statistics`}
-                                element={<Statistics />}
-                            />
-                            <Route path="*" element={<NotFoundPage />}></Route>
+                <Routes>
+                    <Route path={`${routesConfig.BASE_PATH}`} element={<MainLayout />}>
+                        <Route
+                            path={`${routesConfig.BASE_PATH}`}
+                            element={
+                                <Navigate replace={true} to={`${routesConfig.BASE_PATH}/c-chain`} />
+                            }
+                        />
+                        <Route path="c-chain">
+                            <Route index element={<CChainPage />} />
+                            <Route path="blocks" element={<Blocks />} />
+                            <Route path="txs" element={<CTransactions />} />
+                            <Route path="block/:id" element={<BlockDetails />} />
+                            <Route path="tx/:id" element={<TransactionDetails />} />
+                            <Route path="address/:id" element={<Address />} />
                         </Route>
-                    </Routes>
-                ) : null}
+                        <Route path="x-chain">
+                            <Route index element={<XChainPage />} />
+                            <Route path="txs" element={<XPTransactions />} />
+                            <Route path="tx/:id" element={<XPTransactionDetails />} />
+                            <Route path="address/:id" element={<XAddressDetail />} />
+                        </Route>
+                        <Route path="p-chain">
+                            <Route index element={<PChainPage />} />
+                            <Route path="txs" element={<XPTransactions />} />
+                            <Route path="tx/:id" element={<XPTransactionDetails />} />
+                            <Route path="address/:id" element={<XAddressDetail />} />
+                        </Route>
+                        <Route
+                            path={`${routesConfig.BASE_PATH}/mainnet`}
+                            element={<ComingSoonPage />}
+                        />
+                        <Route
+                            path={`${routesConfig.BASE_PATH}/validators`}
+                            element={<Validators />}
+                        />
+                        <Route
+                            path={`${routesConfig.BASE_PATH}/statistics`}
+                            element={<Statistics />}
+                        />
+                    </Route>
+                    <Route
+                        path="*"
+                        element={
+                            <Navigate replace={true} to={`${routesConfig.BASE_PATH}/c-chain`} />
+                        }
+                    ></Route>
+                </Routes>
                 <GlobalStyle />
             </BrowserRouter>
         </>


### PR DESCRIPTION
This PR fixes an issue where navigating to /explorer or /explorer/c-chain directly results in a blank body with only the header and footer visible. The problem occurred because no network was specified in the URL, causing the explorer view to fail to load data.